### PR TITLE
Moved plain `pattern`s to `symbols`

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -7,33 +7,35 @@ syntax.add {
   comment = "#",
   patterns = {
     { pattern = "#.*\n", type = "comment" },
-    
-    -- Keywords
-    { pattern = "FROM", type = "keyword" },
-    { pattern = "ARG", type = "keyword2" },
-    { pattern = "ENV", type = "keyword2" },
-    { pattern = "RUN", type = "keyword2" },
-    { pattern = "ADD", type = "keyword2" },
-    { pattern = "COPY", type = "keyword2" },
-    { pattern = "WORKDIR", type = "keyword2" },
-    { pattern = "USER", type = "keyword2" },
-    { pattern = "LABEL", type = "keyword2" },
-    { pattern = "EXPOSE", type = "keyword2" },
-    { pattern = "VOLUME", type = "keyword2" },
-    { pattern = "ONBUILD", type = "keyword2" },
-    { pattern = "STOPSIGNAL", type = "keyword2" },
-    { pattern = "HEALTHCHECK", type = "keyword2" },
-    { pattern = "SHELL", type = "keyword2" },
-    
+
     -- Functions
-    { pattern = "ENTRYPOINT", type = "function" },
-    { pattern = "CMD", type = "function" },
     { pattern = { "%[", "%]" }, type = "string" },
-    
+
     -- Literals
     { pattern = "%sas%s", type = "literal" },
     { pattern = "--platform=", type = "literal" },
     { pattern = "--chown=", type = "literal" },
+
+    -- Symbols
+    { pattern = "[%a_][%w_]*", type = "symbol" },
   },
-  symbols = {},
+  symbols = {
+    ["FROM"] = "keyword",
+    ["ARG"] = "keyword2",
+    ["ENV"] = "keyword2",
+    ["RUN"] = "keyword2",
+    ["ADD"] = "keyword2",
+    ["COPY"] = "keyword2",
+    ["WORKDIR"] = "keyword2",
+    ["USER"] = "keyword2",
+    ["LABEL"] = "keyword2",
+    ["EXPOSE"] = "keyword2",
+    ["VOLUME"] = "keyword2",
+    ["ONBUILD"] = "keyword2",
+    ["STOPSIGNAL"] = "keyword2",
+    ["HEALTHCHECK"] = "keyword2",
+    ["SHELL"] = "keyword2",
+    ["ENTRYPOINT"] = "function",
+    ["CMD"] = "function",
+  },
 }


### PR DESCRIPTION
For standalone words, the `symbols` table is normally used.

To make it use the `symbols` table, a pattern must match the possible words:
```lua
{ pattern = "[%a_][%w_]*", type = "symbol" },
```
This is the pattern that is generally used.