### PR TITLE
update for lite-xl 2.1 support

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,4 @@
--- mod-version:2 -- lite-xl 2.0
+-- mod-version:3
 local syntax = require "core.syntax"
 
 syntax.add {


### PR DESCRIPTION
* lite-xl version field is no longer used
* mod version got bumped to 3 but no changes are required in the plugin

resolves #3 
requires followup submission to lite-xl-plugins to bump the mod version in the manifest and update the git hash